### PR TITLE
Update pihole.xml

### DIFF
--- a/Spants/pihole.xml
+++ b/Spants/pihole.xml
@@ -58,12 +58,8 @@
   </Networking>
   <Environment>
     <Variable>
-      <Value>8.8.8.8</Value>
-      <Name>DNS1</Name>
-    </Variable>
-    <Variable>
-      <Value>8.8.4.4</Value>
-      <Name>DNS2</Name>
+      <Value>8.8.8.8;8.8.4.4</Value>
+      <Name>PIHOLE_DNS_</Name>
     </Variable>
     <Variable>
       <Value>Europe/London</Value>


### PR DESCRIPTION
`DNS1` and `DNS2` has been [deprecated](https://github.com/pi-hole/docker-pi-hole#deprecated-environment-variables).

