### PR TITLE
Fix CouchDB-v2 template's config dir

### DIFF
--- a/Spants/CouchDB-v2.x.xml
+++ b/Spants/CouchDB-v2.x.xml
@@ -37,7 +37,7 @@
   </Volume>
   <Volume>
     <HostDir>/mnt/user/appdata/couchdb/config</HostDir>
-    <ContainerDir>/usr/local/etc/couchdb</ContainerDir>
+    <ContainerDir>/opt/couchdb/etc/local.d</ContainerDir>
     <Mode>rw</Mode>
   </Volume>
 </Data>


### PR DESCRIPTION
In the couchdb v2 template, the default container dir doesn't work anymore. The configs don't get stored there, and are only kept inside the container. According to (https://github.com/apache/couchdb-docker#configuring-couchdb), the configs should be stored in `/opt/couchdb/etc/local.d` instead. This PR updates the default container dir.